### PR TITLE
LPS-74790 Removed reference target so that associated resources will be checked before deactivating a workflow definition

### DIFF
--- a/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/action/UpdateWorkflowDefinitionMVCActionCommand.java
+++ b/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/action/UpdateWorkflowDefinitionMVCActionCommand.java
@@ -162,7 +162,7 @@ public class UpdateWorkflowDefinitionMVCActionCommand
 		}
 	}
 
-	@Reference(target = "(proxy.bean=false)")
+	@Reference
 	protected WorkflowDefinitionManager workflowDefinitionManager;
 
 }


### PR DESCRIPTION
From @fortunatomaldonado:

> Workflow definitions were able to be deactivated even when they were associated with a resource. The expected outcome would be to not allow the deactivation and to print out an error message to the user.
> 
> @reference(target = "(proxy.bean=false)") was introduced in LPS-71799 and it was preventing WorkflowLinkAdvice from running. After removing the Reference target, WorkflowLinkAdvice was able to run correctly, prevent the deactivation, and the expected output message would output to the screen.
> 
> With target gone, a stack trace will now print to the console whenever a user tries to publish a workflow definition that contains an error. Target was introduced to prevent this from happening, but I believe the user would benefit from the stack trace by being able to locate the error in their definition faster and fix the issue.
