### PR TITLE
LPS-75321 Add toggle for Product Menu Tree replacement

### DIFF
--- a/poshi.toggle
+++ b/poshi.toggle
@@ -1,7 +1,7 @@
 <toggles>
-	<toggle name="JIRA_TICKET">
-		<date>2017-05-24</date>
-		<description>Toggle Description</description>
-		<owner>Full Name</owner>
+	<toggle name="LPS-75321">
+		<date>2017-11-04</date>
+		<description>Replace Product Menu Tree for a new portlet.</description>
+		<owner>Eudaldo Alonso</owner>
 	</toggle>
 </toggles>


### PR DESCRIPTION
Hey @vicnate5,

We need to toggle test for LPS-75321, because we are removing the Product Menu Tree and we are replacing it for a new Portlet called "Site Pages" in the navigation category, please see: https://github.com/anthony-chu/liferay-portal/pull/256 

Regards,
Eudaldo.

cc: @anthony-chu