### PR TITLE
LPS-77172 Order by 'completed' also so that completed tasks are not interspersed with pending ones

### DIFF
--- a/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/impl/internal/WorkflowComparatorFactoryImpl.java
+++ b/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/impl/internal/WorkflowComparatorFactoryImpl.java
@@ -128,9 +128,12 @@ public class WorkflowComparatorFactoryImpl
 		boolean ascending) {
 
 		return new WorkflowTaskCreateDateComparator(
-			ascending, "createDate ASC, kaleoTaskInstanceTokenId ASC",
-			"createDate DESC, kaleoTaskInstanceTokenId DESC",
-			new String[] {"createDate", "kaleoTaskInstanceTokenId"});
+			ascending,
+			"completed ASC, createDate ASC, kaleoTaskInstanceTokenId ASC",
+			"completed DESC, createDate DESC, kaleoTaskInstanceTokenId DESC",
+			new String[] {
+				"completed", "createDate", "kaleoTaskInstanceTokenId"
+			});
 	}
 
 	@Override
@@ -138,9 +141,12 @@ public class WorkflowComparatorFactoryImpl
 		boolean ascending) {
 
 		return new WorkflowTaskDueDateComparator(
-			ascending, "dueDate ASC, modifiedDate ASC, kaleoTaskId ASC",
-			"dueDate DESC, modifiedDate DESC, kaleoTaskId DESC",
-			new String[] {"dueDate", "modifiedDate", "kaleoTaskId"});
+			ascending,
+			"completed ASC, dueDate ASC, modifiedDate ASC, kaleoTaskId ASC",
+			"completed DESC, dueDate DESC, modifiedDate DESC, kaleoTaskId DESC",
+			new String[] {
+				"completed", "dueDate", "modifiedDate", "kaleoTaskId"
+			});
 	}
 
 	@Override


### PR DESCRIPTION
I decided to modify the existing comparators since they appear to only be used by WorkflowTaskPortletUtil. If you would like to add new comparators instead or fix this issue in a different way, please let me know.